### PR TITLE
cm: Put install tools in OUT/install

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -26,15 +26,15 @@ PRODUCT_PROPERTY_OVERRIDES += \
 
 # Backup Tool
 PRODUCT_COPY_FILES += \
-    vendor/slim/prebuilt/common/bin/backuptool.sh:system/bin/backuptool.sh \
-    vendor/slim/prebuilt/common/bin/backuptool.functions:system/bin/backuptool.functions \
+    vendor/slim/prebuilt/common/bin/backuptool.sh:install/bin/backuptool.sh \
+    vendor/slim/prebuilt/common/bin/backuptool.functions:install/bin/backuptool.functions \
     vendor/slim/prebuilt/common/bin/50-slim.sh:system/addon.d/50-slim.sh \
     vendor/slim/prebuilt/common/bin/99-backup.sh:system/addon.d/99-backup.sh \
     vendor/slim/prebuilt/common/etc/backup.conf:system/etc/backup.conf
 
 # Signature compatibility validation
 PRODUCT_COPY_FILES += \
-    vendor/slim/prebuilt/common/bin/otasigcheck.sh:system/bin/otasigcheck.sh
+    vendor/slim/prebuilt/common/bin/otasigcheck.sh:install/bin/otasigcheck.sh
 
 # SLIM-specific init file
 PRODUCT_COPY_FILES += \

--- a/prebuilt/common/bin/backuptool.sh
+++ b/prebuilt/common/bin/backuptool.sh
@@ -7,6 +7,9 @@ export C=/tmp/backupdir
 export S=/system
 export V=Slim-5.1
 
+# Scripts in /system/addon.d expect to find backuptool.functions in /tmp
+cp -f /tmp/install/bin/backuptool.functions /tmp
+
 # Preserve /system/addon.d in /tmp/addon.d
 preserve_addon_d() {
   mkdir -p /tmp/addon.d/


### PR DESCRIPTION
- This allows us to avoid modifying /system at install time.

Change-Id: I747551d7f38a3eef70ab64f32b6d4a4749c01012
